### PR TITLE
Added missing 'android:exported' directive. Crashing build on Android 12

### DIFF
--- a/plugin/build/withAndroidReactNativeMSAL.js
+++ b/plugin/build/withAndroidReactNativeMSAL.js
@@ -15,7 +15,7 @@ function setBrowserTabActivity(config, androidManifest, signatureHash) {
     const mainApplication = getMainApplicationOrThrow(androidManifest);
     let activity = (_a = mainApplication.activity) === null || _a === void 0 ? void 0 : _a.find((a) => a.$['android:name'] === BROWSER_TAB_ACTIVITY_NAME);
     if (!activity) {
-        activity = { $: { 'android:name': BROWSER_TAB_ACTIVITY_NAME } };
+        activity = { $: { 'android:name': BROWSER_TAB_ACTIVITY_NAME, 'android:exported': 'false'  } };
         mainApplication.activity = [...((_b = mainApplication.activity) !== null && _b !== void 0 ? _b : []), activity];
     }
     activity['intent-filter'] = [

--- a/plugin/src/withAndroidReactNativeMSAL.ts
+++ b/plugin/src/withAndroidReactNativeMSAL.ts
@@ -26,7 +26,7 @@ function setBrowserTabActivity(
   const mainApplication = getMainApplicationOrThrow(androidManifest);
   let activity = mainApplication.activity?.find((a) => a.$['android:name'] === BROWSER_TAB_ACTIVITY_NAME);
   if (!activity) {
-    activity = { $: { 'android:name': BROWSER_TAB_ACTIVITY_NAME } };
+    activity = { $: { 'android:name': BROWSER_TAB_ACTIVITY_NAME, 'android:exported': 'false'  } };
     mainApplication.activity = [...(mainApplication.activity ?? []), activity];
   }
   activity['intent-filter'] = [


### PR DESCRIPTION
When using Expo 49, or targeting android 12+. It gives the following error:

```
Error:
        android:exported needs to be explicitly specified for element <activity#com.microsoft.identity.client.BrowserTabActivity>. Apps targeting Android 12 and higher are required to specify an explicit value for `android:exported` when the corresponding component has an intent filter defined. See https://developer.android.com/guide/topics/manifest/activity-element#exported for details.
```

The workaround was manually change Android.manifest, adding the missing `'android:exported': 'false'` directive.

This fixes this bug.