### PR TITLE
fix: Remove prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "clean": "expo-module clean",
     "expo-module": "expo-module",
     "lint": "expo-module lint",
-    "prepare": "expo-module prepare && husky install",
     "prepublishOnly": "expo-module prepublishOnly",
     "test": "expo-module test",
     "example": "yarn --cwd example",


### PR DESCRIPTION
Removed the prepare script from package.json as it was causing issues with yarn in the pull request validation pipeline for MAD Platform.

Ref: https://github.com/yarnpkg/yarn/issues/7212#issuecomment-493720324